### PR TITLE
Fix deprecation of using s

### DIFF
--- a/ttp/ttp.py
+++ b/ttp/ttp.py
@@ -149,7 +149,7 @@ def lazy_import_functions():
                     if target.id == "_name_map_":
                         _name_map_.update(
                             {
-                                key.s: assignment.value.values[index].s
+                                key.value: assignment.value.values[index].value
                                 for index, key in enumerate(assignment.value.keys)
                             }
                         )


### PR DESCRIPTION
Received a deprecation warning in pytest about using s. It will be removed in Python 3.14.
Changed s to value.