### PR TITLE
added line_number match function

### DIFF
--- a/docs/source/Match Variables/Functions.rst
+++ b/docs/source/Match Variables/Functions.rst
@@ -37,6 +37,8 @@ Action functions act upon match result to transform into desired state.
      - join matches using provided character
    * - `let`_
      - Assigns provided value to match variable
+   * - `line_number`_
+     - save the line number where the match was found
    * - `lookup`_
      - find match value in lookup table and return result
    * - `mac_eui`_
@@ -992,6 +994,46 @@ Result::
                         "interface": "Te5/7"
                     }
                 ]
+            }
+        ]
+    ]
+
+line_number
+------------------------------------------------------------------------------
+``{{ name | line_number(new_field) }}``
+
+* new_field - field name to store the line number
+
+Data::
+
+ object-group service ServiceGroup
+   description "DESC"
+   test1 ok test2 fail
+   enable
+ exit
+
+Template::
+
+ object-group service {{ name | line_number("service_name_line")}}
+   description "{{ description | line_number("description_line")}}"
+   enable {{ enable | set(True) | line_number("enable_line") }}
+   test1 {{ test1 | line_number("test1_line")}} test2 {{ test2 | line_number("test2_line")}}
+
+Result::
+
+    [
+        [
+            {
+                "name": "ServiceGroup",
+                "service_name_line": 1
+                "description": "DESC",
+                "description_line": 2,
+                "enable": True,
+                "enable_line": 4,
+                "test1": "ok", 
+                "test1_line": 3,
+                "test2": "fail", 
+                "test2_line": 3,
             }
         ]
     ]

--- a/ttp/match/line_number.py
+++ b/ttp/match/line_number.py
@@ -1,0 +1,6 @@
+def line_number(data, new_field, context):
+    span_length = context.match.end() - context.match.start()
+    if _ttp_["parser_object"].DATANAME == "text_data":
+        line_number = _ttp_["parser_object"].DATATEXT[:context.span_start + span_length].count("\n")
+        return data, {"new_field": {new_field: line_number}}
+    return data, True


### PR DESCRIPTION
The improvement suggested [here](https://github.com/dmulyalin/ttp/issues/96) turned out to be useful to me too.
I tried to implement it.

To do this, I needed to pass some data regarding the current match being processed into the function, which I couldn't obtain otherwise.

For convenience (and possible future expansion?), I combined this data into a single object – MatchContext.

This object is passed only to functions that have a "context" parameter in their signature.

If you have any suggestions, please let me know.

